### PR TITLE
Fix create emote and be able to copy a emote url

### DIFF
--- a/create-emote/ContextMenuInjection.jsx
+++ b/create-emote/ContextMenuInjection.jsx
@@ -33,7 +33,7 @@ export default ({ isEmote, emoteAlt, url }) => (
             ))}
         </ContextMenu.MenuItem>
         <ContextMenu.MenuItem
-            label="Copy link"
+            label="Copy URL"
             id="ysink_emoji_copyitem"
             action={() => {
                 let emoteNewName = emoteAlt?.substring(1, emoteAlt.length - 1);

--- a/create-emote/ContextMenuInjection.jsx
+++ b/create-emote/ContextMenuInjection.jsx
@@ -1,33 +1,48 @@
 import { findByProps } from "@cumcord/modules/webpack";
 import { showToast } from "@cumcord/ui/toasts";
+import { copyText } from "@cumcord/utils";
 import { guildsCanManageEmotes, uploadEmoji } from "./discordTools.js";
 import showCreateModal from "./CreateModal.jsx";
 
 const ContextMenu = findByProps("MenuGroup", "default");
 
 export default ({ isEmote, emoteAlt, url }) => (
-    <ContextMenu.MenuItem
-        id="ysink_emoji_msgitem"
-        label={isEmote ? `Clone Emote ${emoteAlt}` : "Create Emote"}
-    >
-        {guildsCanManageEmotes().map((guild) => (
-            <ContextMenu.MenuItem
-                label={guild.name}
-                id={`ysink_emoji_server_${guild.id}`}
-                action={() => {
-                    let emoteNewName = emoteAlt?.substring(
-                        1,
-                        emoteAlt.length - 1
-                    );
-                    if (isEmote) {
-                        uploadEmoji(guild.id, url, emoteNewName);
-                        showToast({
-                            title: `cloned emote ${emoteNewName}`,
-                            duration: 3000,
-                        });
-                    } else showCreateModal(guild.id, url);
-                }}
-            />
-        ))}
-    </ContextMenu.MenuItem>
+    <>
+        <ContextMenu.MenuItem
+            id="ysink_emoji_msgitem"
+            label={isEmote ? `Clone Emote ${emoteAlt}` : "Create Emote"}
+        >
+            {guildsCanManageEmotes().map((guild) => (
+                <ContextMenu.MenuItem
+                    label={guild.name}
+                    id={`ysink_emoji_server_${guild.id}`}
+                    action={() => {
+                        let emoteNewName = emoteAlt?.substring(
+                            1,
+                            emoteAlt.length - 1
+                        );
+                        if (isEmote) {
+                            uploadEmoji(guild.id, url, emoteNewName);
+                            showToast({
+                                title: `cloned emote ${emoteNewName}`,
+                                duration: 3000,
+                            });
+                        } else showCreateModal(guild.id, url);
+                    }}
+                />
+            ))}
+        </ContextMenu.MenuItem>
+        <ContextMenu.MenuItem
+            label="Copy link"
+            id="ysink_emoji_copyitem"
+            action={() => {
+                let emoteNewName = emoteAlt?.substring(1, emoteAlt.length - 1);
+                copyText(url);
+                showToast({
+                    title: `Copied url for ${emoteNewName}`,
+                    duration: 3000,
+                });
+            }}
+        />
+    </>
 );

--- a/create-emote/discordTools.js
+++ b/create-emote/discordTools.js
@@ -3,13 +3,13 @@ import { findByProps } from "@cumcord/modules/webpack";
 const discordEmojiTools = findByProps("uploadEmoji");
 const { getGuildPermissions } = findByProps("getGuildPermissions");
 
-const getGuilds = findByProps("getFlattenedGuilds").getFlattenedGuilds;
+const { getGuilds } = findByProps("getGuilds");
 
 const MANAGE_EMOTES_PERMISSION = BigInt(1073741824);
 
 const canManageEmotes = (guildId) => {
     let guildperms = getGuildPermissions({ id: guildId });
-    if (guildperms && (guildperms & MANAGE_EMOTES_PERMISSION) !== 0) {
+    if (guildperms && (guildperms & MANAGE_EMOTES_PERMISSION) !== 0n) {
         return true;
     } else {
         return false;
@@ -17,7 +17,7 @@ const canManageEmotes = (guildId) => {
 };
 
 const guildsCanManageEmotes = () =>
-    getGuilds().filter((guild) => canManageEmotes(guild.id));
+    Object.values(getGuilds()).filter((guild) => canManageEmotes(guild.id));
 
 // many many many tabs of stackoverflow and MDN, and about 30 mins later
 const promisifiedFileReader = (blob) =>

--- a/create-emote/patchEmotePicker.jsx
+++ b/create-emote/patchEmotePicker.jsx
@@ -1,44 +1,27 @@
-import { findByProps, find } from "@cumcord/modules/webpack";
+import { find } from "@cumcord/modules/webpack";
 import { after } from "@cumcord/patcher";
 import ContextMenuInjection from "./ContextMenuInjection.jsx";
 
-const ContextMenu = findByProps("MenuGroup", "default");
-const contextMenuTools = findByProps("openContextMenu");
-
 export default () => {
-    const emojiPickerListRow = find(
-        (m) => m?.default?.displayName == "EmojiPickerListRow"
+    const EmojiContextMenu = find(
+        (m) => m.default?.displayName === "ExpressionPickerContextMenu"
     );
 
-    return after("default", emojiPickerListRow, (args, retVal) => {
-        if (!Array.isArray(retVal?.props?.children)) return retVal;
+    return after("default", EmojiContextMenu, ([{ target }], retVal) => {
+        if (!target.firstChild.currentSrc) return retVal;
+        if (!Array.isArray(retVal.props.children.props.children))
+            retVal.props.children.props.children = [
+                retVal.props.children.props.children,
+            ];
 
-        for (const emoji of retVal.props.children) {
-            if (!emoji || !emoji?.props?.children) continue;
+        retVal.props.children.props.children.push(
+            ContextMenuInjection({
+                isEmote: true,
+                emoteAlt: `:${target.dataset.name}:`,
+                url: target.firstChild.currentSrc,
+            })
+        );
 
-            let selectedEmoji = emoji.props.children.props.emoji;
-            emoji.props.onContextMenu = (e) => {
-                let selectedEmojiUrl = selectedEmoji.managed
-                    ? `https://discord.com${selectedEmoji.url}`
-                    : selectedEmoji.url;
-
-                contextMenuTools.openContextMenu(e, () => (
-                    <ContextMenu.default
-                        onClose={contextMenuTools.closeContextMenu}
-                    >
-                        {/*
-                            due to discord throwing errors if I just pass this as a component,
-                            i'll call it manually,
-                            as the root of this component is the allowed ContextMenu.MenuItem
-                         */}
-                        {ContextMenuInjection({
-                            isEmote: true,
-                            emoteAlt: `:${selectedEmoji.name}:`,
-                            url: selectedEmojiUrl,
-                        })}
-                    </ContextMenu.default>
-                ));
-            };
-        }
+        return retVal;
     });
 };


### PR DESCRIPTION
This fixes the plugin and adds a option to copy a emote url. Also discord added a context menu for emotes so it will start injecting there.

A image if you wanted:
![image](https://user-images.githubusercontent.com/54505527/140624603-14db459e-7c64-4ad7-8aac-0564a08f203c.png)

